### PR TITLE
fixes compromised event_stream package

### DIFF
--- a/package.json
+++ b/package.json
@@ -88,5 +88,8 @@
     "redux": "^4.0.1",
     "redux-thunk": "^2.3.0",
     "url-loader": "^1.1.2"
+  },
+  "resolutions": {
+    "**/event-stream": "^4.0.1"
   }
 }


### PR DESCRIPTION
The version of the `event-stream` package used here has been compromised with malicious code in one of its transitive dependencies. See: https://blog.npmjs.org/post/180565383195/details-about-the-event-stream-incident

As a result the package was deleted from the NPM repository. In effect the Iris build is current broken. This PR pulls in the fixed `event-stream` package. 

It looks like the `yarn.lock` was build with an older Yarn version <1.10. Regenerating it with a recent Yarn version strips the integrity tags. Unsure of what the workflow for generating the lock file - I left that as a follow up exercise.